### PR TITLE
Make the spotlights dynamic.

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -13,7 +13,9 @@ namespace App\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface;
 use Nines\BlogBundle\Entity\Page;
+use Nines\BlogBundle\Entity\Post;
 use Nines\UtilBundle\Controller\PaginatorTrait;
+use Proxies\__CG__\Nines\BlogBundle\Entity\PostCategory;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,10 +36,29 @@ class DefaultController extends AbstractController implements PaginatorAwareInte
      * @return array
      */
     public function indexAction(EntityManagerInterface $em) {
-        $repo = $em->getRepository(Page::class);
-        $page = $repo->findHomepage();
+        $pageRepo = $em->getRepository(Page::class);
+
+        $spotlightCategories = [
+            $em->find(PostCategory::class, 1),
+            $em->find(PostCategory::class, 2),
+            $em->find(PostCategory::class, 3),
+        ];
+        $qb = $em->createQueryBuilder();
+        $qb->select('p');
+        $qb->from(Post::class, 'p');
+        $qb->where('p.category = :category');
+        $qb->innerJoin('p.status', 's');
+        $qb->andWhere('s.public = 1');
+        $qb->orderBy('p.id', 'desc');
+
+        $spotlights = [];
+        foreach($spotlightCategories as $cat) {
+            $spotlights[] = $qb->getQuery()->setParameter('category', $cat)->getOneOrNullResult();
+        }
+
         return [
-            'homepage' => $page,
+            'homepage' => $pageRepo->findHomepage(),
+            'spotlights' => $spotlights,
         ];
     }
 

--- a/templates/default/index.html.twig
+++ b/templates/default/index.html.twig
@@ -2,39 +2,30 @@
 
 {% block body %}
 
-    <div class="col-sm-12">
+    <div class='row'>
+        <div class="col-sm-12">
 
-        {% if homepage %}
-            {{ homepage.content|raw }}
-        {% endif %}
+            {% if homepage %}
+                {{ homepage.content|raw }}
+            {% endif %}
 
-        <h2>Spotlights</h2>
+            <h2>Spotlights</h2>
+        </div>
     </div>
-    <div class="col-sm-4 blog-panel blog-1">
-        <a href="{{ path('nines_blog_post_show', {'id': 4}) }}">
-            <div class="panel panel-default">
-                <div class="panel-image"></div>
-                <div class="panel-heading">Mother Shipton / Ursula Southeil: The Oldest Woman in WPHP</div>
-            </div>
-        </a>
-    </div>
-    <div class="col-sm-4 blog-panel blog-2">
-        <a href="{{ path('nines_blog_post_show', {'id': 2}) }}">
-            <div class="panel panel-default">
-                <div class="panel-image"></div>
-                <div class="panel-heading">Martha Gurney: Abolitionist Bookseller of Holborn Hill</div>
-            </div>
-        </a>
-    </div>
-    <div class="col-sm-4 blog-panel blog-3">
-        <a href="{{ path('nines_blog_post_show', {'id': 1}) }}">
-            <div class="panel panel-default">
-                <div class="panel-image"></div>
-                <div class="panel-heading">A New System of Domestic Cookery: the bestselling cookbook of the 19th
-                    century
+
+    <div class='row'>
+
+        {% for spotlight in spotlights %}
+            <div class="col-sm-4 blog-panel">
+                <div class="panel panel-default">
+                    <a href="{{ path('nines_blog_post_show', {'id': spotlight.id}) }}">
+                        <div class="panel-heading">{{ spotlight.title }}</div>
+                    </a>
+                    <div class='panel-body'>{{ spotlight.excerpt|raw }}</div>
                 </div>
             </div>
-        </a>
+        {% endfor %}
+
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Only the most recent spotlight from each spotlight category will
appear on the home page in this order: People, Firms, Titles. The home
page will only display the title and excerpt. Users will need to
follow the link on the title to get to the full post.

fixes sfu-dhil/wphp#104