### PR TITLE
Compare years in two ways when searching for a person by name and date.

### DIFF
--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -62,11 +62,11 @@ class PersonRepository extends ServiceEntityRepository {
         $qb->setParameter('first', $firstName);
 
         if ($dob) {
-            $qb->andWhere('YEAR(e.dob) = :dob');
+            $qb->andWhere('(e.dob = :dob) OR (YEAR(e.dob) = :dob)');
             $qb->setParameter('dob', $dob);
         }
         if ($dod) {
-            $qb->andWhere('YEAR(e.dod) = :dod');
+            $qb->andWhere('(e.dod = :dod) OR (YEAR(e.dod) = :dod)');
             $qb->setParameter('dod', $dod);
         }
 


### PR DESCRIPTION
MySQL thinks that year(1999) === null, so that's a bad thing.

fixes sfu-dhil/wphp#162