### PR TITLE
Person name search

### DIFF
--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -87,8 +87,14 @@ class PersonRepository extends ServiceEntityRepository {
         $qb->addOrderBy('e.firstName');
         $qb->addOrderBy('e.dob');
         if (isset($data['name']) && $data['name']) {
-            $qb->andWhere('MATCH (e.lastName, e.firstName, e.title) AGAINST (:name BOOLEAN) > 0');
-            $qb->setParameter('name', $data['name']);
+            $matches = [];
+            if(preg_match('/^"(.*?)"$/', $data['name'], $matches)) {
+                $qb->andWhere('CONCAT(e.firstName, \' \', e.lastName) LIKE :name');
+                $qb->setParameter('name', $matches[1]);
+            } else {
+                $qb->andWhere('MATCH (e.lastName, e.firstName, e.title) AGAINST (:name BOOLEAN) > 0');
+                $qb->setParameter('name', $data['name']);
+            }
         }
         if (isset($data['order']) && $data['order']) {
             switch ($data['order']) {


### PR DESCRIPTION
The problem here is that the first name and last name fields are different. So when searching for a person by name we must search the first name and last name fields.

So I have changed the person name search so that including quotes around a name will change the nature of searching from a full text match to a first name last name comparison.

Examples:
 - `"charlotte smith"` will find the one Charlotte Smith in the database.
 - `charlotte smith` will find all the charlottes and all the smiths
 - `"rachel biggs"` will not find Rachel Charlotte Biggs because the search  term must include Charlotte.
 - `"rachel%biggs"` will find Rachel Charlotte Biggs. % is a wildcard  character for this one specific case.

fixes sfu-dhil/wphp#223