### PR TITLE
Rewrite ESTC imprint search.

### DIFF
--- a/src/Repository/EstcMarcRepository.php
+++ b/src/Repository/EstcMarcRepository.php
@@ -65,15 +65,21 @@ ENDSQL;
      * @return mixed
      */
     public function imprintSearchQuery($q) {
-        $dql = <<<'ENDSQL'
-SELECT e.titleId, max(MATCH (e.fieldData) AGAINST (:q BOOLEAN)) as HIDDEN score
-FROM App:EstcMarc e
-WHERE MATCH (e.fieldData) AGAINST (:q BOOLEAN) > 0 AND e.field = '260' and e.subfield = 'b'
-group by e.titleId order by score desc
-ENDSQL;
-        $query = $this->_em->createQuery($dql);
-        $query->setParameter('q', $q);
+        $qb = $this->createQueryBuilder('e');
+        $qb->select('e.titleId');
+        $qb->addSelect('MAX(MATCH(e.fieldData) AGAINST (:q BOOLEAN)) AS HIDDEN score');
+        $qb->andWhere('e.field = \'260\'');
+        $qb->andWhere('e.subfield = \'b\'');
+        $qb->andHaving('score > 0');
+        $qb->groupBy('e.titleId');
+        $qb->orderBy('score', 'DESC');
+        $qb->setParameter('q', $q);
 
-        return $query->execute();
+        $matches = [];
+        if(preg_match('/^"(.*?)"$/', $q, $matches)) {
+            $qb->andWhere('e.fieldData LIKE :text');
+            $qb->setParameter('text', '%' . $matches[1] . '%');
+        }
+        return $qb->getQuery()->execute();
     }
 }

--- a/templates/estc_marc/show.html.twig
+++ b/templates/estc_marc/show.html.twig
@@ -10,19 +10,36 @@
     <div class="btn-toolbar">
         <div class="btn-group pull-right">
             <a href="{{ path('resource_estc_index') }}" class="btn btn-default">
-                <span class="glyphicon glyphicon-arrow-left"></span> Back
-            </a>
+                <span class="glyphicon glyphicon-arrow-left"></span> Back </a>
             <a href="{{ path('title_marc_import', {'id': estcMarc.titleId}) }}" class="btn btn-default" target="_blank">
-                <span class="glyphicon glyphicon-save"></span> Import
-            </a>
+                <span class="glyphicon glyphicon-save"></span> Import </a>
         </div>
     </div>
+    {% set data = manager.getData(estcMarc) %}
+
+    <details>
+        <summary>Control Info</summary>
+        <table class="table table-bordered table-condensed table-hover table-striped">
+            <tbody>
+                {% for field in data|filter(f => f.field < 100) %}
+                    <tr>
+                        <th style='white-space: normal' data-toggle="popover" data-content='{{ manager.getFieldName(field) }}'>
+                            {{ manager.getFieldName(field)|u.truncate(20, '...', false) }} ({{ field }})
+                        </th>
+                        <td>{{ field.getFieldData() }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </details>
+
     <table class="table table-bordered table-condensed table-hover table-striped">
-        {% set data = manager.getData(estcMarc) %}
         <tbody>
-            {% for field in data %}
+            {% for field in data|filter(f => f.field >= 100) %}
                 <tr>
-                    <th>{{ manager.getFieldName(field) }} ({{ field }})</th>
+                    <th style='white-space: normal' data-toggle="popover" data-content='{{ manager.getFieldName(field) }}'>
+                        {{ manager.getFieldName(field)|u.truncate(20, '...', false) }} ({{ field }})
+                    </th>
                     <td>{{ field.getFieldData() }}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Similar to how the person name search works, if you include quotes then
the quoted string must be present in the result.

`"a. james"` the search results will filter out anything not containing
that string, including punctuation. The filter is case insensitive,
so `"A. JAMES"` will return the same result.

`a. james` searches exactly the same as before.

fixes sfu-dhil/wphp#222