### PR TITLE
Address shortcomings in the AAS import

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -31,6 +31,7 @@ security:
                 samesite: strict
                 httponly: true
                 name: WPHP_REMEMBER_ME
+                remember_me_parameter: remember_me
 
     role_hierarchy:
         ROLE_ADMIN:       [ ROLE_ADMIN, ROLE_BLOG_ADMIN, ROLE_COMMENT_ADMIN, ROLE_CONTENT_ADMIN, ROLE_DC_ADMIN, ROLE_USER_ADMIN ]

--- a/migrations/2021/12/Version20211214173504.php
+++ b/migrations/2021/12/Version20211214173504.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211214173504 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE title CHANGE pubdate pubdate VARCHAR(60) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE title CHANGE pubdate pubdate VARCHAR(40) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/src/Command/ConvertEstcCommand.php
+++ b/src/Command/ConvertEstcCommand.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Command;
+
+use App\Repository\EstcMarcRepository;
+use App\Services\EstcMarcImporter;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use PhpMarc\Field;
+use PhpMarc\File;
+use PhpMarc\Record;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConvertEstcCommand extends Command {
+    //100 - Personal Name
+    //a. Personal name
+    //c. titles
+    //q. fuller form of name
+    //260 - Publication
+    //b. Name of publisher
+    //f. Manufacturer
+    //264 - Production
+    //b. Name of producer
+    //700 - Added entry - Personal Name
+    //a. Personal name
+    //c. titles
+    //q. fuller form of name
+
+    public const NAME_FIELDS = [
+        '100' => ['a', 'q'],
+        '700' => ['a', 'q'],
+    ];
+
+    public const TITLE_FIELDS = [
+        '100' => ['c'],
+        '700' => ['c'],
+    ];
+
+    public const NAME_PUNCT = [
+        '/(\w\w).$/u' => '$1',
+        '/,$/u' => '',
+    ];
+
+    private bool $save = false;
+
+    private EntityManagerInterface $em;
+
+    private int $n = 0;
+
+    /**
+     * @var string[]
+     */
+    private array $names;
+
+    private EstcMarcImporter $importer;
+
+    /**
+     * @var array|array[]|false[]|null[]|string[]|\string[][]
+     */
+    private array $titles;
+
+    private EstcMarcRepository $estcMarcRepository;
+
+    protected static $defaultName = 'wphp:convert:estc';
+
+    protected static $defaultDescription = 'Add a short description for your command';
+
+    protected function configure() : void {
+        $this->setDescription(self::$defaultDescription);
+        $this->addArgument('path', InputArgument::IS_ARRAY, 'One or more files to import');
+        $this->addOption('save', null, InputOption::VALUE_NONE, 'Save converted records');
+    }
+
+    protected function dot(bool $finished = false) : void {
+        $this->n++;
+        if ($this->save) {
+            $this->em->flush();
+            $this->em->clear();
+        }
+        echo "\r{$this->n}";
+        if ($finished) {
+            echo "\nfinished\n";
+        }
+    }
+
+    /**
+     * Wrapper around $this->em->persist that does nothing unless self::SAVE is
+     * true.
+     */
+    protected function save(object $object) : void {
+        if ($this->save) {
+            $this->em->persist($object);
+        }
+    }
+
+    /**
+     * Read the list of women's names and titles.
+     */
+    protected function getNames() : void {
+        $data = file_get_contents('data/women.txt');
+        $data = preg_split("/\n/u", $data);
+        $data = array_map(fn ($s) => preg_replace('/^\s+|\s+$/u', '', $s), $data);
+        $data = array_filter($data);
+        $data = array_map(fn ($s) => mb_convert_case($s, MB_CASE_LOWER), $data);
+        $this->names = $data;
+
+        $data = file_get_contents('data/titles.txt');
+        $data = preg_split("/\n/u", $data);
+        $data = array_map(fn ($s) => preg_replace('/^\s+|\s+$/u', '', $s), $data);
+        $data = array_filter($data);
+        $data = array_map(fn ($s) => mb_convert_case($s, MB_CASE_LOWER), $data);
+        $this->titles = $data;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int {
+        $this->em->getConnection()->getConfiguration()->setSQLLogger(null);
+//        set_error_handler([$this, 'errorHandler']);
+        $this->save = $input->getOption('save');
+        $this->getNames();
+
+        foreach ($input->getArgument('path') as $path) {
+            echo "\n{$path}\n";
+            $file = new File();
+            $file->file($path);
+            $record = $file->next();
+            while ($record) {
+                if ($this->checkTitle($record) || $this->checkName($record)) {
+//                    $estcMarc = $this->estcMarcRepository->findOneBy([
+//                        'field' => '001',
+//                        'fieldData' => $record->field('001')->data,
+//                    ]);
+//                    $title = $this->importer->import($estcMarc->getTitleId());
+//                    foreach($title->getTitleSources() as $ts) {
+//                        $this->em->persist($ts);
+//                    }
+//                    $this->save($title);
+                }
+//                $this->dot(false);
+
+                try {
+                    $record = $file->next();
+                } catch (Exception $e) {
+                    $output->writeln("\n" . $e->getMessage());
+                }
+            }
+        }
+        $this->dot(true);
+
+        return 0;
+    }
+
+    protected function checkTitle(Record $record) : bool {
+        foreach (self::TITLE_FIELDS as $id => $subs) {
+            $fields = $record->fields[$id] ?? [];
+            foreach ($fields as $field) {
+                foreach ($subs as $s) {
+                    if ( ! ($data = $field->subfields[$s] ?? null)) {
+                        continue;
+                    }
+                    foreach ($this->titles as $title) {
+                        $m = [];
+                        if (preg_match("/\\b({$title})\\b/ui", $data, $m)) {
+                            echo implode("|", [
+                                'title', $title, $data, $id . $s, $record->field('001')->data(),
+                                    $record->subfield('245', 'a'), 'http://estc.bl.uk/' . $record->field('001')->data()
+                            ]) . "\n";
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    protected function checkName(Record $record) : bool {
+        foreach (self::NAME_FIELDS as $id => $subs) {
+            /** @var Field[] $fields */
+            $fields = $record->fields[$id] ?? [];
+            foreach ($fields as $field) {
+                foreach ($subs as $s) {
+                    if (( ! $data = $field->subfields[$s] ?? null)) {
+                        continue;
+                    }
+                    $given = preg_replace('/^[^,]*,\\s*/u', '', $data);
+                    foreach ($this->names as $name) {
+                        $m = [];
+                        if (preg_match("/\\b({$name})\\b/ui", $given, $m)) {
+                            echo implode("|", [
+                                    'name', $name, $data, $id . $s, $record->field('001')->data(),
+                                    $record->subfield('245', 'a'), 'http://estc.bl.uk/' . $record->field('001')->data()
+                                ]) . "\n";
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function errorHandler(int $errno, string $errstr, string $errfile, int $errline, array $errcontext) : void {
+        throw new Exception($errstr, $errno);
+    }
+
+    /**
+     * @required
+     */
+    public function setEntityManager(EntityManagerInterface $em) : void {
+        $this->em = $em;
+    }
+
+    /**
+     * @required
+     */
+    public function setEstcMarcImporter(EstcMarcImporter $importer) : void {
+        $this->importer = $importer;
+    }
+
+    /**
+     * @required
+     */
+    public function setEstcMarcRepository(EstcMarcRepository $estcMarcRepository) : void {
+        $this->estcMarcRepository = $estcMarcRepository;
+    }
+}

--- a/src/Command/ConvertEstcCommand.php
+++ b/src/Command/ConvertEstcCommand.php
@@ -76,6 +76,7 @@ class ConvertEstcCommand extends Command {
     protected static $defaultName = 'wphp:convert:estc';
 
     protected static $defaultDescription = 'Add a short description for your command';
+    private int $saved = 0;
 
     protected function configure() : void {
         $this->setDescription(self::$defaultDescription);
@@ -89,7 +90,7 @@ class ConvertEstcCommand extends Command {
             $this->em->flush();
             $this->em->clear();
         }
-        echo "\r{$this->n}";
+        echo "\r{$this->n} - {$this->saved}";
         if ($finished) {
             echo "\nfinished\n";
         }
@@ -100,6 +101,7 @@ class ConvertEstcCommand extends Command {
      * true.
      */
     protected function save(object $object) : void {
+        $this->saved++;
         if ($this->save) {
             $this->em->persist($object);
         }
@@ -137,17 +139,17 @@ class ConvertEstcCommand extends Command {
             $record = $file->next();
             while ($record) {
                 if ($this->checkTitle($record) || $this->checkName($record)) {
-//                    $estcMarc = $this->estcMarcRepository->findOneBy([
-//                        'field' => '001',
-//                        'fieldData' => $record->field('001')->data,
-//                    ]);
-//                    $title = $this->importer->import($estcMarc->getTitleId());
-//                    foreach($title->getTitleSources() as $ts) {
-//                        $this->em->persist($ts);
-//                    }
-//                    $this->save($title);
+                    $estcMarc = $this->estcMarcRepository->findOneBy([
+                        'field' => '001',
+                        'fieldData' => $record->field('001')->data,
+                    ]);
+                    $title = $this->importer->import($estcMarc->getTitleId());
+                    foreach($title->getTitleSources() as $ts) {
+                        $this->em->persist($ts);
+                    }
+                    $this->save($title);
                 }
-//                $this->dot(false);
+                $this->dot();
 
                 try {
                     $record = $file->next();
@@ -172,10 +174,6 @@ class ConvertEstcCommand extends Command {
                     foreach ($this->titles as $title) {
                         $m = [];
                         if (preg_match("/\\b({$title})\\b/ui", $data, $m)) {
-                            echo implode("|", [
-                                'title', $title, $data, $id . $s, $record->field('001')->data(),
-                                    $record->subfield('245', 'a'), 'http://estc.bl.uk/' . $record->field('001')->data()
-                            ]) . "\n";
                             return true;
                         }
                     }
@@ -199,10 +197,6 @@ class ConvertEstcCommand extends Command {
                     foreach ($this->names as $name) {
                         $m = [];
                         if (preg_match("/\\b({$name})\\b/ui", $given, $m)) {
-                            echo implode("|", [
-                                    'name', $name, $data, $id . $s, $record->field('001')->data(),
-                                    $record->subfield('245', 'a'), 'http://estc.bl.uk/' . $record->field('001')->data()
-                                ]) . "\n";
                             return true;
                         }
                     }

--- a/src/Command/ImportEstcCommand.php
+++ b/src/Command/ImportEstcCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Command;
+
+use App\Entity\EstcMarc;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use PhpMarc\File;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImportEstcCommand extends Command {
+    private int $n = 0;
+
+    private bool $save = false;
+
+    private EntityManagerInterface $em;
+
+    protected static $defaultName = 'wphp:import:estc';
+
+    protected static $defaultDescription = 'Import ESTC MARC data';
+
+    protected function configure() : void {
+        $this->setDescription(self::$defaultDescription);
+        $this->addArgument('path', InputArgument::IS_ARRAY, 'One or more files to import');
+        $this->addOption('save', null, InputOption::VALUE_NONE, 'Save converted records');
+    }
+
+    protected function dot(bool $finished = false) : void {
+        $this->n++;
+        if ($this->save && ($finished || 0 === $this->n % 100)) {
+            $this->em->flush();
+            $this->em->clear();
+            echo "\r{$this->n}";
+        }
+        if ($finished) {
+            echo " - finished\n";
+        }
+    }
+
+    /**
+     * Wrapper around $this->em->persist that does nothing unless self::SAVE is
+     * true.
+     */
+    protected function save(object $object) : void {
+        if ($this->save) {
+            $this->em->persist($object);
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int {
+        $this->em->getConnection()->getConfiguration()->setSQLLogger(null);
+        set_error_handler([$this, 'errorHandler']);
+        $this->save = $input->getOption('save');
+        $recordCount = 234043; // manually set.
+        foreach ($input->getArgument('path') as $path) {
+            echo "\n{$path}\n";
+            $file = new File();
+            $file->file($path);
+            $record = $file->next();
+            while ($record) {
+                $ldr = new EstcMarc();
+                $ldr->setTitleId($recordCount);
+                $ldr->setField('ldr');
+                $ldr->setFieldData($record->ldr);
+                $this->save($ldr);
+
+                foreach ($record->fields() as $fields) {
+                    foreach ($fields as $field) {
+                        if ($field->is_control) {
+                            $ctrl = new EstcMarc();
+                            $ctrl->setTitleId($recordCount);
+                            $ctrl->setField($field->tagno);
+                            $ctrl->setFieldData($field->data);
+                            $this->save($ctrl);
+                        }
+
+                        foreach ($field->subfields as $subfield => $value) {
+                            $estc = new EstcMarc();
+                            $estc->setTitleId($recordCount);
+                            $estc->setField($field->tagno);
+                            $estc->setSubfield($subfield);
+                            $estc->setFieldData($value);
+                            $this->save($estc);
+                            $this->dot();
+                        }
+                    }
+                }
+                $recordCount++;
+
+                try {
+                    $record = $file->next();
+                } catch (Exception $e) {
+                    $output->writeln("\n" . $e->getMessage());
+                }
+            }
+        }
+        $this->dot(true);
+
+        return 0;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function errorHandler(int $errno, string $errstr, string $errfile, int $errline, array $errcontext) : void {
+        throw new Exception($errstr, $errno);
+    }
+
+    /**
+     * @required
+     */
+    public function setEntityManager(EntityManagerInterface $em) : void {
+        $this->em = $em;
+    }
+}

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -50,6 +50,7 @@ class PersonController extends AbstractController implements PaginatorAwareInter
         $form = $this->createForm(PersonSearchType::class, null, [
             'action' => $this->generateUrl('person_search'),
             'entity_manager' => $em,
+            'user' => $this->getUser(),
         ]);
         $dql = 'SELECT e FROM App:Person e';
         if (null === $this->getUser()) {
@@ -101,7 +102,7 @@ class PersonController extends AbstractController implements PaginatorAwareInter
      * @return BinaryFileResponse
      */
     public function searchExportCsvAction(Request $request, EntityManagerInterface $em, PersonRepository $repo, CsvExporter $exporter) {
-        $form = $this->createForm(PersonSearchType::class, null, ['entity_manager' => $em]);
+        $form = $this->createForm(PersonSearchType::class, null, ['entity_manager' => $em, 'user' => $this->getUser()]);
         $form->handleRequest($request);
         $persons = [];
 
@@ -130,14 +131,17 @@ class PersonController extends AbstractController implements PaginatorAwareInter
      * @return array
      */
     public function searchAction(Request $request, PersonRepository $repo, EntityManagerInterface $em) {
-        $form = $this->createForm(PersonSearchType::class, null, ['entity_manager' => $em]);
+        $form = $this->createForm(PersonSearchType::class, null, [
+            'entity_manager' => $em,
+            'user' => $this->getUser()
+        ]);
         $form->handleRequest($request);
         $persons = [];
         $submitted = false;
 
         if ($form->isSubmitted()) {
             $submitted = true;
-            $query = $repo->buildSearchQuery($form->getData());
+            $query = $repo->buildSearchQuery($form->getData(), $this->getUser());
             $persons = $this->paginator->paginate($query, $request->query->getInt('page', 1), 25);
         }
 

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -52,6 +52,9 @@ class PersonController extends AbstractController implements PaginatorAwareInter
             'entity_manager' => $em,
         ]);
         $dql = 'SELECT e FROM App:Person e';
+        if (null === $this->getUser()) {
+            $dql .= ' WHERE (e.finalcheck = 1)';
+        }
         $query = $em->createQuery($dql);
         $people = $this->paginator->paginate($query, $request->query->getInt('page', 1), 25, [
             'defaultSortFieldName' => ['e.lastName', 'e.firstName', 'e.dob'],

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Entity\Title;
+use App\Entity\TitleRole;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface;
 use Nines\UtilBundle\Controller\PaginatorTrait;
@@ -141,6 +142,50 @@ class ReportController extends AbstractController implements PaginatorAwareInter
             ->where('title.editionChecked = 0')
             ->orderBy('title.id', 'ASC')
         ;
+
+        $titles = $this->paginator->paginate($qb, $request->query->getInt('page', 1), 25);
+
+        return [
+            'titles' => $titles,
+        ];
+    }
+
+    /**
+     * @Route("/titles_unverified_persons", name="titles_unverified_persons", methods={"GET"})
+     * @Template
+     *
+     * @return array
+     */
+    public function titlesWithUnverifiedPersons(Request $request, EntityManagerInterface $em) {
+        $qb = $em->createQueryBuilder();
+        $qb->select('title')
+            ->from(Title::class, 'title')
+            ->innerJoin('title.titleRoles', 'tr')
+            ->innerJoin('tr.person', 'p')
+            ->where('p.finalcheck = 0')
+            ->andWhere('(title.checked = 1 OR title.finalattempt = 1 OR title.finalcheck = 1)');
+
+        $titles = $this->paginator->paginate($qb, $request->query->getInt('page', 1), 25);
+
+        return [
+            'titles' => $titles,
+        ];
+    }
+
+    /**
+     * @Route("/titles_unverified_firms", name="titles_unverified_firms", methods={"GET"})
+     * @Template
+     *
+     * @return array
+     */
+    public function titlesWithUnverifiedFirms(Request $request, EntityManagerInterface $em) {
+        $qb = $em->createQueryBuilder();
+        $qb->select('title')
+            ->from(Title::class, 'title')
+            ->innerJoin('title.titleFirmroles', 'tfr')
+            ->innerJoin('tfr.firm', 'f')
+            ->where('f.finalcheck = 0')
+            ->andWhere('(title.checked = 1 OR title.finalattempt = 1 OR title.finalcheck = 1)');
 
         $titles = $this->paginator->paginate($qb, $request->query->getInt('page', 1), 25);
 

--- a/src/Entity/Title.php
+++ b/src/Entity/Title.php
@@ -94,7 +94,7 @@ class Title {
     /**
      * @var string
      *
-     * @ORM\Column(name="pubdate", type="string", length=40, nullable=true)
+     * @ORM\Column(name="pubdate", type="string", length=60, nullable=true)
      */
     private $pubdate;
 

--- a/src/Form/Firm/FirmSearchType.php
+++ b/src/Form/Firm/FirmSearchType.php
@@ -26,6 +26,7 @@ class FirmSearchType extends AbstractType {
      * Build the form.
      */
     public function buildForm(FormBuilderInterface $builder, array $options) : void {
+        $user=  $options['user'];
         $builder->setMethod('get');
 
         $builder->add('name', TextType::class, [
@@ -124,6 +125,23 @@ class FirmSearchType extends AbstractType {
                 'class' => 'embedded-form',
             ],
         ]);
+        if($user) {
+            $builder->add('finalcheck', ChoiceType::class, [
+                'label' => 'Verified',
+                'choices' => [
+                    'Yes' => 'Y',
+                    'No' => 'N',
+                ],
+                'attr' => [
+                    'help_block' => 'firm.search.finalcheck',
+                ],
+                'required' => false,
+                'expanded' => true,
+                'multiple' => false,
+                'empty_data' => null,
+                'data' => null,
+            ]);
+        }
     }
 
     /**
@@ -131,5 +149,6 @@ class FirmSearchType extends AbstractType {
      */
     public function configureOptions(OptionsResolver $resolver) : void {
         parent::configureOptions($resolver);
+        $resolver->setRequired(['user']);
     }
 }

--- a/src/Form/Person/PersonSearchType.php
+++ b/src/Form/Person/PersonSearchType.php
@@ -27,6 +27,7 @@ class PersonSearchType extends AbstractType {
      * Build the form.
      */
     public function buildForm(FormBuilderInterface $builder, array $options) : void {
+        $user = $options['user'];
         $builder->setMethod('get');
 
         $builder->add('name', TextType::class, [
@@ -154,6 +155,23 @@ class PersonSearchType extends AbstractType {
                 'class' => 'embedded-form',
             ],
         ]);
+        if($user) {
+            $builder->add('finalcheck', ChoiceType::class, [
+                'label' => 'Verified',
+                'choices' => [
+                    'Yes' => 'Y',
+                    'No' => 'N',
+                ],
+                'attr' => [
+                    'help_block' => 'person.search.finalcheck',
+                ],
+                'required' => false,
+                'expanded' => true,
+                'multiple' => false,
+                'empty_data' => null,
+                'data' => null,
+            ]);
+        }
     }
 
     /**
@@ -161,6 +179,6 @@ class PersonSearchType extends AbstractType {
      */
     public function configureOptions(OptionsResolver $resolver) : void {
         parent::configureOptions($resolver);
-        $resolver->setRequired(['entity_manager']);
+        $resolver->setRequired(['entity_manager', 'user']);
     }
 }

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -197,6 +197,12 @@ class Builder implements ContainerAwareInterface {
             $browse->addChild('Editions to Check', [
                 'route' => 'report_editions_to_check',
             ]);
+            $browse->addChild('Titles with Unverified People', [
+                'route' => 'titles_unverified_persons'
+            ]);
+            $browse->addChild('Titles with Unverified Firms', [
+                'route' => 'titles_unverified_firms'
+            ]);
         }
 
         return $menu;

--- a/src/Repository/FirmRepository.php
+++ b/src/Repository/FirmRepository.php
@@ -14,6 +14,7 @@ use App\Entity\Firm;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query;
 use Doctrine\Persistence\ManagerRegistry;
+use Nines\UserBundle\Entity\User;
 
 /**
  * FirmRepository.
@@ -49,10 +50,11 @@ class FirmRepository extends ServiceEntityRepository {
      * parameters from the firm search and does smart things with them.
      *
      * @param array $data The search form's data from $form->getData().
+     * @param ?User $user
      *
      * @return Query
      */
-    public function buildSearchQuery($data) {
+    public function buildSearchQuery($data, $user) {
         $qb = $this->createQueryBuilder('e');
         $qb->orderBy('e.name');
         $qb->addOrderBy('e.startDate');
@@ -170,6 +172,15 @@ class FirmRepository extends ServiceEntityRepository {
                 $qb->setParameter('frome', $from);
                 $qb->setParameter('toe', $to);
             }
+        }
+
+        if($user) {
+            if(isset($data['finalcheck'])) {
+                $qb->andWhere('e.finalcheck = :finalcheck');
+                $qb->setParameter('finalcheck', 'Y' === $data['finalcheck']);
+            }
+        } else {
+            $qb->andWhere('e.finalcheck = 1');
         }
 
         if (isset($data['title_filter']) && count(array_filter($data['title_filter']))) {

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Query;
 use Doctrine\Persistence\ManagerRegistry;
+use Nines\UserBundle\Entity\User;
 
 /**
  * PersonRepository.
@@ -78,10 +79,11 @@ class PersonRepository extends ServiceEntityRepository {
      * Build and return a complex search query from a search form.
      *
      * @param array $data
+     * @param ?User $user
      *
      * @return Query
      */
-    public function buildSearchQuery($data) {
+    public function buildSearchQuery($data, $user) {
         $qb = $this->createQueryBuilder('e');
         $qb->orderBy('e.lastName');
         $qb->addOrderBy('e.firstName');
@@ -252,6 +254,15 @@ class PersonRepository extends ServiceEntityRepository {
                 $qb->andWhere('MATCH(e.imageUrl) AGAINST(:imageUrl BOOLEAN) > 0');
                 $qb->setParameter('imageUrl', $data['imageUrl']);
             }
+        }
+
+        if($user) {
+            if(isset($data['finalcheck'])) {
+                $qb->andWhere('e.finalcheck = :finalcheck');
+                $qb->setParameter('finalcheck', 'Y' === $data['finalcheck']);
+            }
+        } else {
+            $qb->andWhere('e.finalcheck = 1');
         }
 
         if (isset($data['title_filter']) && count(array_filter($data['title_filter']))) {

--- a/src/Services/EstcMarcImporter.php
+++ b/src/Services/EstcMarcImporter.php
@@ -136,8 +136,10 @@ class EstcMarcImporter {
      * @return Person[]
      */
     public function getPerson($fields) {
+        if( ! isset($fields['100a'])) {
+            return [];
+        }
         $fullName = preg_replace('/[^a-zA-Z0-9]*$/', '', $fields['100a']->getFieldData());
-        echo "\n" . $fullName . "\n";
         if(mb_strpos($fullName, ',')) {
             [$last, $first] = explode(', ', $fullName);
             [$dob, $dod] = $this->getDates($fields);
@@ -271,8 +273,9 @@ class EstcMarcImporter {
         $format = $this->guessFormat($fields);
         $title->setFormat($format);
 
-        foreach($this->getPerson($fields) as $person) {
-            $this->addAuthor($title, $person);
+        $authors = $this->getPerson($fields);
+        if(count($authors) > 0) {
+            $this->addAuthor($title, $authors[0]);
         }
 
         [$width, $height] = $this->guessDimensions($fields);

--- a/src/Services/EstcMarcImporter.php
+++ b/src/Services/EstcMarcImporter.php
@@ -12,12 +12,15 @@ namespace App\Services;
 
 use App\Entity\EstcMarc;
 use App\Entity\Format;
+use App\Entity\Person;
 use App\Entity\Role;
 use App\Entity\Source;
 use App\Entity\Title;
+use App\Entity\TitleRole;
 use App\Entity\TitleSource;
 use App\Repository\EstcMarcRepository;
 use App\Repository\FormatRepository;
+use App\Repository\PersonRepository;
 use App\Repository\RoleRepository;
 use App\Repository\SourceRepository;
 use App\Repository\TitleRepository;
@@ -54,6 +57,11 @@ class EstcMarcImporter {
     private $sourceRepo;
 
     /**
+     * @var PersonRepository
+     */
+    private $personRepo;
+
+    /**
      * @var FormatRepository
      */
     private $formatRepo;
@@ -77,6 +85,7 @@ class EstcMarcImporter {
         $this->titleRepo = $this->em->getRepository(Title::class);
         $this->roleRepo = $this->em->getRepository(Role::class);
         $this->sourceRepo = $this->em->getRepository(Source::class);
+        $this->personRepo = $this->em->getRepository(Person::class);
         $this->formatRepo = $this->em->getRepository(Format::class);
         $this->titleSourceRepository = $this->em->getRepository(TitleSource::class);
         $this->messages = [];
@@ -117,6 +126,24 @@ class EstcMarcImporter {
         ]))) {
             $this->messages[] = 'This ESTC ID already exists in the database. Please check that you are not duplicating data.';
         }
+    }
+
+    /**
+     * Attempt to fetch a person record based on a MARC record.
+     *
+     * @param array $fields
+     *
+     * @return Person[]
+     */
+    public function getPerson($fields) {
+        $fullName = preg_replace('/[^a-zA-Z0-9]*$/', '', $fields['100a']->getFieldData());
+        echo "\n" . $fullName . "\n";
+        if(mb_strpos($fullName, ',')) {
+            [$last, $first] = explode(', ', $fullName);
+            [$dob, $dod] = $this->getDates($fields);
+            return $this->personRepo->findByNameDates($first, $last, $dob, $dod);
+        }
+        return [];
     }
 
     /**
@@ -244,12 +271,32 @@ class EstcMarcImporter {
         $format = $this->guessFormat($fields);
         $title->setFormat($format);
 
-        list($width, $height) = $this->guessDimensions($fields);
+        foreach($this->getPerson($fields) as $person) {
+            $this->addAuthor($title, $person);
+        }
+
+        [$width, $height] = $this->guessDimensions($fields);
         $title->setSizeL($width);
         $title->setSizeW($height);
         $title->setChecked(false);
 
         return $title;
+    }
+
+    /**
+     * Add the person to a title as an author.
+     */
+    public function addAuthor(Title $title, Person $person) : void {
+        if ( ! $person) {
+            return;
+        }
+        $role = $this->roleRepo->findOneBy(['name' => 'Author']);
+        $titleRole = new TitleRole();
+        $titleRole->setPerson($person);
+        $titleRole->setRole($role);
+        $titleRole->setTitle($title);
+        $title->addTitleRole($titleRole);
+        $this->em->persist($titleRole);
     }
 
     /**

--- a/templates/report/titles_with_unverified_firms.html.twig
+++ b/templates/report/titles_with_unverified_firms.html.twig
@@ -1,0 +1,51 @@
+{% extends 'base.html.twig' %}
+
+{% block pageheader %}
+    <h1>Titles to Final Check</h1>
+    {% if titles|length > 0 %}
+        Displaying {{ titles|length }} titles of {{ titles.getTotalItemCount }} total
+        which are verified and also refer to unverified firms
+    {% else %}
+        No titles to display.
+    {% endif %}
+{% endblock %}
+
+{% block body %}
+
+    {% if titles|length > 0 %}
+        {% embed 'partial/table.html.twig' %}
+            {% set entities = titles %}
+            {% block thead %}
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Attempted Verification</th>
+                    <th>Verified</th>
+                    <th>Pub Date</th>
+                    <th>First Pub Date</th>
+                </tr>
+            {% endblock %}
+            {% block tbody %}
+                {% for title in titles %}
+                    <tr>
+                        <td>
+                            <a href="{{ path('title_show', { 'id': title.id }) }}">
+                                {{ title.id }}
+                            </a>
+                        </td>
+                        <td>
+                            <a href="{{ path('title_show', { 'id': title.id }) }}">
+                                {{ title.title }}
+                            </a>
+                        </td>
+                        <td>{% if title.finalattempt %}Yes{% else %}No{% endif %}</td>
+                        <td>{% if title.finalcheck %}Yes{% else %}No{% endif %}</td>
+                        <td>{{ title.pubdate }}</td>
+                        <td>{{ title.dateOfFirstPublication }}</td>
+                    </tr>
+                {% endfor %}
+            {% endblock %}
+        {% endembed %}
+    {% endif %}
+
+{% endblock %}

--- a/templates/report/titles_with_unverified_persons.html.twig
+++ b/templates/report/titles_with_unverified_persons.html.twig
@@ -1,0 +1,51 @@
+{% extends 'base.html.twig' %}
+
+{% block pageheader %}
+    <h1>Titles to Final Check</h1>
+    {% if titles|length > 0 %}
+        Displaying {{ titles|length }} titles of {{ titles.getTotalItemCount }} total
+        which are verified and also refer to unverified persons
+    {% else %}
+        No titles to display.
+    {% endif %}
+{% endblock %}
+
+{% block body %}
+
+    {% if titles|length > 0 %}
+        {% embed 'partial/table.html.twig' %}
+            {% set entities = titles %}
+            {% block thead %}
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Attempted Verification</th>
+                    <th>Verified</th>
+                    <th>Pub Date</th>
+                    <th>First Pub Date</th>
+                </tr>
+            {% endblock %}
+            {% block tbody %}
+                {% for title in titles %}
+                    <tr>
+                        <td>
+                            <a href="{{ path('title_show', { 'id': title.id }) }}">
+                                {{ title.id }}
+                            </a>
+                        </td>
+                        <td>
+                            <a href="{{ path('title_show', { 'id': title.id }) }}">
+                                {{ title.title }}
+                            </a>
+                        </td>
+                        <td>{% if title.finalattempt %}Yes{% else %}No{% endif %}</td>
+                        <td>{% if title.finalcheck %}Yes{% else %}No{% endif %}</td>
+                        <td>{{ title.pubdate }}</td>
+                        <td>{{ title.dateOfFirstPublication }}</td>
+                    </tr>
+                {% endfor %}
+            {% endblock %}
+        {% endembed %}
+    {% endif %}
+
+{% endblock %}

--- a/templates/title/show.html.twig
+++ b/templates/title/show.html.twig
@@ -57,6 +57,9 @@
                                         {% if person.finalCheck or app.user %}
                                             <li>
                                                 <a href="{{ path('person_show', {'id': person.id}) }}">{{ person }}</a> ({{ tr.role.name }})
+                                                {% if not person.finalCheck %}
+                                                    <i>(unverified)</i>
+                                                {% endif %}
                                             </li>
                                         {% endif %}
                                     {% endfor %}
@@ -79,10 +82,14 @@
                                     <ul>
                                         {% for tfr in title.titleFirmRoles %}
                                             {% set firm = tfr.firm %}
-                                            <li>
-                                                <a href="{{ path('firm_show', {'id': firm.id}) }}">{{ firm.name }}</a>
-                                                ({{ tfr.firmrole }})
-                                            </li>
+                                            {% if firm.finalCheck or app.user %}
+                                                <li>
+                                                    <a href="{{ path('firm_show', {'id': firm.id}) }}">{{ firm.name }}</a> ({{ tfr.firmrole }})
+                                                    {% if not firm.finalCheck %}
+                                                        <i>(unverified)</i>
+                                                    {% endif %}
+                                                </li>
+                                            {% endif %}
                                         {% endfor %}
                                     </ul>
                                 {% endif %}

--- a/templates/title/show.html.twig
+++ b/templates/title/show.html.twig
@@ -54,9 +54,11 @@
                                 <ul>
                                     {% for tr in title.titleRoles %}
                                         {% set person = tr.person %}
-                                        <li>
-                                            <a href="{{ path('person_show', {'id': person.id}) }}">{{ person }}</a> ({{ tr.role.name }})
-                                        </li>
+                                        {% if person.finalCheck or app.user %}
+                                            <li>
+                                                <a href="{{ path('person_show', {'id': person.id}) }}">{{ person }}</a> ({{ tr.role.name }})
+                                            </li>
+                                        {% endif %}
                                     {% endfor %}
                                 </ul>
                             {% endif %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -127,6 +127,7 @@ firm:
     gender: Search by gender of the firm or leave unchecked to include all genders
     name: Search for all or part of a firm name
     startDate: Search by year (eg <kbd>1795</kbd>) or range of years (<kbd>1790-1800</kbd>) or a partial range of years (<kbd>*-1800</kbd>)
+    finalcheck: Limit results to firm records that have been verified or not verified
 
 geonames:
   fields: &geonames_fields
@@ -186,6 +187,7 @@ person:
     name: Search for all or part of a person's name
     viafUrl: Enter a VIAF URI to check if we have a corresponding record. Enter <kbd>blank</kbd> to find records which do not have VIAF URIs.
     wikipediaUrl: Enter a Wikipedia URL to check if we have a corresponding record. Enter <kbd>blank</kbd> to find records which do not have Wikipedia URLs.
+    finalcheck: Limit results to person records that have been verified or not verified
 
 source:
   fields: &source_fields


### PR DESCRIPTION
Two new reports

- titles with unverified persons
- titles with unverified firms (not requested but seemed like a good idea)

 Also adds '(unverified)' to contributors and firms for logged in users.

- fixes sfu-dhil/wphp#301

Add verified as a search field for persons and firms. Option is only
available to logged in users, and anonymous users only get verified results.

- fixes sfu-dhil/wphp#302

Hide unverified persons on verified titles

- fixes sfu-dhil/wphp#300

Hide unverified person records

- fixes sfu-dhil/wphp#299

Some other issues fixed:

 * Make the remember_me login option work.
 * Widen the pubDate field.