### PR TITLE
Fix long title searches

### DIFF
--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -252,7 +252,6 @@ class ReportController extends AbstractController implements PaginatorAwareInter
             ->andWhere('ts.source = 75')
             ;
 
-
         $titles = $this->paginator->paginate($qb, $request->query->getInt('page', 1), 25, [
             'defaultSortFieldName' => ['title.title', 'title.pubdate'],
             'defaultSortDirection' => 'asc',

--- a/src/Entity/Title.php
+++ b/src/Entity/Title.php
@@ -329,6 +329,21 @@ class Title extends AbstractEntity {
         return $this->title;
     }
 
+    /**
+     * Get trimmed title.
+     *
+     * @return string
+     */
+    public function getTrimmedTitle() {
+        if (str_word_count($this->title) > 128) {
+            $words = explode(' ', $this->title, 129);
+
+            return implode(' ', array_slice($words, 0, 128));
+        }
+
+        return $this->title;
+    }
+
     public function getFormId() : string {
         return "({$this->id}) {$this->title}";
     }

--- a/src/Repository/TitleRepository.php
+++ b/src/Repository/TitleRepository.php
@@ -98,7 +98,7 @@ class TitleRepository extends ServiceEntityRepository {
         $qb->addSelect('MATCH(title.title) AGAINST (:title BOOLEAN) AS score');
         $qb->andHaving('score > 5.0');
         $qb->orderBy('score', 'desc');
-        $result = $qb->getQuery()->execute(['title' => '"' . $title->getTitle() . '"']);
+        $result = $qb->getQuery()->execute(['title' => '"' . $title->getTrimmedTitle() . '"']);
 
         // MySQL's full text indexing is good, but not good enough for this. It
         // finds a lot of false positives, so filter them out with a quick


### PR DESCRIPTION
MySQL/MariaDB has a 128 max word limit on MATCH AGAINST queries. This fix limits the total words used to 128 which prevents the error but does lead to a smaller chance of the `Similar Titles` section being populated for very long titles

Closes #344 